### PR TITLE
Implement exam submission web app

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "exam-feedback-app-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.4.0"
+  },
+  "scripts": {
+    "start": "echo 'Run a React build tool like Vite or CRA'"
+  }
+}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import Admin from './components/Admin.js';
+
+function Login({ onLogin }) {
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+  return (
+    <div>
+      <h2>Login</h2>
+      <input placeholder="Student ID" value={id} onChange={e => setId(e.target.value)} />
+      <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      <button onClick={async () => {
+        const res = await axios.post('/api/login', { studentId: id, password });
+        onLogin(res.data.token);
+      }}>Login</button>
+    </div>
+  );
+}
+
+function ExamForm({ token }) {
+  const [exams, setExams] = useState([]);
+  const [examId, setExamId] = useState('');
+  const [score, setScore] = useState('');
+  const [strength, setStrength] = useState('');
+  const [weakness, setWeakness] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  useEffect(() => { axios.get('/api/exams').then(r => setExams(r.data)); }, []);
+
+  const submit = async () => {
+    const res = await axios.post(`/api/exams/${examId}/submit`, { score, strength, weakness }, { headers: { Authorization: `Bearer ${token}` } });
+    setFeedback(res.data.feedback);
+  };
+
+  return (
+    <div>
+      <h2>Submit Score</h2>
+      <select onChange={e => setExamId(e.target.value)} value={examId}>
+        <option value="">Select exam</option>
+        {exams.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
+      </select>
+      <input placeholder="Score" value={score} onChange={e => setScore(e.target.value)} />
+      <input placeholder="Strength" value={strength} onChange={e => setStrength(e.target.value)} />
+      <input placeholder="Weakness" value={weakness} onChange={e => setWeakness(e.target.value)} />
+      <button onClick={submit}>Submit</button>
+      {feedback && <p>AI Feedback: {feedback}</p>}
+    </div>
+  );
+}
+
+export default function App() {
+  const [token, setToken] = useState('');
+  const [role, setRole] = useState('student');
+  if (!token) return <Login onLogin={(tk) => { setToken(tk); const payload = JSON.parse(atob(tk.split('.')[1])); setRole(payload.role); }} />;
+  if (role === 'admin') return <Admin token={token} />;
+  return <ExamForm token={token} />;
+}

--- a/client/src/components/Admin.js
+++ b/client/src/components/Admin.js
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function Admin({ token }) {
+  const [name, setName] = useState('');
+  const [open, setOpen] = useState('');
+  const [close, setClose] = useState('');
+  const create = async () => {
+    await axios.post('/api/admin/exams', { name, openDate: open, closeDate: close }, { headers: { Authorization: `Bearer ${token}` } });
+    alert('Created');
+  };
+  return (
+    <div>
+      <h2>Create Exam</h2>
+      <input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+      <input placeholder="Open" value={open} onChange={e => setOpen(e.target.value)} />
+      <input placeholder="Close" value={close} onChange={e => setClose(e.target.value)} />
+      <button onClick={create}>Create</button>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import authRoutes from './routes/auth.js';
+import examRoutes from './routes/exams.js';
+import adminRoutes from './routes/admin.js';
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+app.use('/api', authRoutes);
+app.use('/api', examRoutes);
+app.use('/api/admin', adminRoutes);
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "exam-feedback-app-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2",
+    "jsonwebtoken": "^9.0.0",
+    "bcrypt": "^5.1.0",
+    "googleapis": "^105.0.0",
+    "axios": "^1.4.0"
+  }
+}

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import { authMiddleware, adminOnly } from '../services/auth.js';
+import { createExam, getSubmissions } from '../services/sheets.js';
+
+const router = express.Router();
+
+router.post('/exams', authMiddleware, adminOnly, async (req, res) => {
+  const { name, openDate, closeDate } = req.body;
+  if (!name) return res.status(400).json({ error: 'Missing exam name' });
+  try {
+    await createExam({ name, openDate, closeDate });
+    res.json({ message: 'Exam created' });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create exam' });
+  }
+});
+
+router.get('/reports', authMiddleware, adminOnly, async (req, res) => {
+  const { examId, year } = req.query;
+  const data = await getSubmissions({ examId, year });
+  res.json(data);
+});
+
+export default router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,34 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import { appendUser, findUserById } from '../services/sheets.js';
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+router.post('/register', async (req, res) => {
+  const { name, studentId, year, major, faculty, password } = req.body;
+  if (!name || !studentId || !password) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  const hash = await bcrypt.hash(password, 10);
+  try {
+    await appendUser({ name, studentId, year, major, faculty, password: hash, role: 'student' });
+    const token = jwt.sign({ studentId, role: 'student' }, SECRET);
+    res.json({ token });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to register' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { studentId, password } = req.body;
+  const user = await findUserById(studentId);
+  if (!user) return res.status(401).json({ error: 'User not found' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Incorrect password' });
+  const token = jwt.sign({ studentId, role: user.role }, SECRET);
+  res.json({ token });
+});
+
+export default router;

--- a/server/routes/exams.js
+++ b/server/routes/exams.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { getExams, appendSubmission } from '../services/sheets.js';
+import { generateFeedback } from '../services/ai.js';
+import { authMiddleware } from '../services/auth.js';
+
+const router = express.Router();
+
+router.get('/exams', async (req, res) => {
+  const exams = await getExams();
+  res.json(exams);
+});
+
+router.post('/exams/:id/submit', authMiddleware, async (req, res) => {
+  const examId = req.params.id;
+  const { score, strength, weakness } = req.body;
+  const tokenData = req.user;
+  try {
+    const feedback = await generateFeedback(score, strength, weakness);
+    await appendSubmission({
+      date: new Date().toISOString(),
+      studentId: tokenData.studentId,
+      examId,
+      score,
+      strength,
+      weakness,
+      feedback
+    });
+    res.json({ feedback });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to submit' });
+  }
+});
+
+export default router;

--- a/server/services/ai.js
+++ b/server/services/ai.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export async function generateFeedback(score, strength, weakness) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return 'No API key provided.';
+  const prompt = `คะแนนสอบ: ${score}\nจุดแข็ง: ${strength}\nจุดอ่อน: ${weakness}\nให้คำแนะนำสั้น ๆ เป็นภาษาไทย`; 
+  try {
+    const res = await axios.post('https://api.openai.com/v1/chat/completions', {
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    }, {
+      headers: { 'Authorization': `Bearer ${apiKey}` }
+    });
+    return res.data.choices[0].message.content.trim();
+  } catch (e) {
+    return 'ไม่สามารถสร้างคำแนะนำได้';
+  }
+}

--- a/server/services/auth.js
+++ b/server/services/auth.js
@@ -1,0 +1,26 @@
+import jwt from 'jsonwebtoken';
+import { findUserById } from './sheets.js';
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+export async function authMiddleware(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ error: 'No token' });
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, SECRET);
+    const user = await findUserById(payload.studentId);
+    if (!user) throw new Error('user not found');
+    req.user = payload;
+    next();
+  } catch (e) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+export function adminOnly(req, res, next) {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Admins only' });
+  }
+  next();
+}

--- a/server/services/sheets.js
+++ b/server/services/sheets.js
@@ -1,0 +1,74 @@
+import { google } from 'googleapis';
+
+const spreadsheetId = process.env.SHEET_ID;
+const credentials = process.env.GOOGLE_CREDENTIALS ? JSON.parse(process.env.GOOGLE_CREDENTIALS) : null;
+
+function getClient() {
+  if (!credentials) throw new Error('No Google credentials');
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets']
+  });
+  return google.sheets({ version: 'v4', auth });
+}
+
+export async function appendUser(user) {
+  const sheets = getClient();
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: 'Users!A1',
+    valueInputOption: 'USER_ENTERED',
+    requestBody: { values: [[user.studentId, user.name, user.year, user.major, user.faculty, user.password, user.role]] }
+  });
+}
+
+export async function findUserById(studentId) {
+  if (!credentials) return null;
+  const sheets = getClient();
+  const res = await sheets.spreadsheets.values.get({ spreadsheetId, range: 'Users!A2:G' });
+  const rows = res.data.values || [];
+  for (const row of rows) {
+    if (row[0] === studentId) {
+      return { studentId: row[0], name: row[1], year: row[2], major: row[3], faculty: row[4], password: row[5], role: row[6] };
+    }
+  }
+  return null;
+}
+
+export async function createExam(exam) {
+  const sheets = getClient();
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: 'Exams!A1',
+    valueInputOption: 'USER_ENTERED',
+    requestBody: { values: [[exam.name, exam.openDate, exam.closeDate]] }
+  });
+}
+
+export async function getExams() {
+  const sheets = getClient();
+  const res = await sheets.spreadsheets.values.get({ spreadsheetId, range: 'Exams!A2:C' });
+  const rows = res.data.values || [];
+  return rows.map((r, i) => ({ id: i + 1, name: r[0], openDate: r[1], closeDate: r[2] }));
+}
+
+export async function appendSubmission(data) {
+  const sheets = getClient();
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: 'Submissions!A1',
+    valueInputOption: 'USER_ENTERED',
+    requestBody: { values: [[data.date, data.studentId, data.examId, data.score, data.strength, data.weakness, data.feedback]] }
+  });
+}
+
+export async function getSubmissions(filter) {
+  const sheets = getClient();
+  const res = await sheets.spreadsheets.values.get({ spreadsheetId, range: 'Submissions!A2:G' });
+  const rows = res.data.values || [];
+  let results = rows.map(r => ({
+    date: r[0], studentId: r[1], examId: r[2], score: r[3], strength: r[4], weakness: r[5], feedback: r[6]
+  }));
+  if (filter.examId) results = results.filter(r => r.examId === filter.examId);
+  return results;
+}


### PR DESCRIPTION
## Summary
- initialize backend with Express server
- add JWT-based auth and Google Sheet integration for storing user accounts, exams and submissions
- add AI feedback service using OpenAI
- implement React frontend for login, exam submission, and admin exam creation

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688b0afc2818832fbb768577593422bc